### PR TITLE
Add Adwaita backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly
+    - name: Install system dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y libadwaita-1-dev libgtk-4-dev
+    - name: Install system dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install libadwaita gtk4
     - name: Build and Test
       run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,16 @@ license.workspace = true
 [dependencies]
 nuit-derive.workspace = true
 nuit-core.workspace = true
+# TODO: Scope this under not(apple) to avoid pulling it in on macOS?
+# Would be nice to have https://github.com/rust-lang/cargo/issues/1197
+nuit-bridge-adwaita.workspace = true
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 nuit-bridge-swiftui.workspace = true
 
 [workspace]
 members = [
+    "nuit-bridge-adwaita",
     "nuit-bridge-swiftui",
     "nuit-core",
     "nuit-derive",
@@ -29,6 +33,7 @@ license = "GPL-3.0-or-later"
 homepage = "https://github.com/fwcd/nuit"
 
 [workspace.dependencies]
+nuit-bridge-adwaita = { version = "0.0.7", path = "nuit-bridge-adwaita" }
 nuit-bridge-swiftui = { version = "0.0.7", path = "nuit-bridge-swiftui" }
 nuit-core = { version = "0.0.7", path = "nuit-core" }
 nuit-derive = { version = "0.0.7", path = "nuit-derive" }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Nuit's API takes inspiration from SwiftUI, Xilem, React and a number of other fr
 > - [associated type defaults](https://github.com/rust-lang/rust/issues/29661)
 > - [macro metavariable expressions](https://github.com/rust-lang/rust/issues/83527)
 > - [`let` chains](https://github.com/rust-lang/rust/issues/53667)
+> - [reentrant locks](https://github.com/rust-lang/rust/issues/121440)
 >
 > With `rustup` this can be configured conveniently on a per-directory basis `rustup override set nightly` or, as in this repository, automatically with a [`rust-toolchain.toml`](rust-toolchain.toml).
 

--- a/examples/adwaita.rs
+++ b/examples/adwaita.rs
@@ -1,0 +1,35 @@
+#![feature(type_alias_impl_trait, impl_trait_in_assoc_type)]
+
+use nuit::{Backend, Bind, Button, ConfigBuilder, State, Text, VStack, View};
+
+#[derive(Bind)]
+struct CounterView {
+    count: State<i32>,
+}
+
+impl CounterView {
+    fn new() -> Self {
+        Self { count: State::new(0) }
+    }
+}
+
+impl View for CounterView {
+    type Body = impl View;
+
+    fn body(&self) -> Self::Body {
+        let count = self.count.clone();
+        VStack::new((
+            Text::new(format!("Count: {}", count.get())),
+            Button::new(Text::new("Increment"), move || {
+                count.set(count.get() + 1);
+            })
+        ))
+    }
+}
+
+fn main() {
+    nuit::run_app(
+        ConfigBuilder::from(CounterView::new())
+            .preferred_backend(Backend::Adwaita)
+    );
+}

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -36,7 +36,7 @@ impl CounterView {
 }
 
 impl Bind for CounterView {
-    fn bind(&mut self, context: &Context) {
+    fn bind(&self, context: &Context) {
         self.count.link(context.storage().clone(), context.id_path(), 0);
     }
 }

--- a/nuit-bridge-adwaita/Cargo.toml
+++ b/nuit-bridge-adwaita/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "nuit-bridge-adwaita"
+description = "Adwaita bindings for Nuit"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[dependencies]
+nuit-core.workspace = true

--- a/nuit-bridge-adwaita/Cargo.toml
+++ b/nuit-bridge-adwaita/Cargo.toml
@@ -7,4 +7,5 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
+adw = { package = "libadwaita", version = "0.7" }
 nuit-core.workspace = true

--- a/nuit-bridge-adwaita/README.md
+++ b/nuit-bridge-adwaita/README.md
@@ -1,0 +1,3 @@
+# Nuit Bridge Adwaita
+
+An Adwaita/GTK4 backend for Nuit.

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use adw::{gtk::{Box, Orientation}, prelude::*, Application, ApplicationWindow, HeaderBar};
 use node_widget::NodeWidget;
-use nuit_core::{Root, View};
+use nuit_core::{IdPath, Root, View};
 
 pub fn run_app<T>(root: Root<T>) where T: View + 'static {
     let root = Arc::new(Mutex::new(root));
@@ -14,7 +14,7 @@ pub fn run_app<T>(root: Root<T>) where T: View + 'static {
 
     app.connect_activate(move |app| {
         let node = Root::render(&mut root.lock().unwrap());
-        let node_widget = NodeWidget::from(node);
+        let node_widget = NodeWidget::from_node(node, IdPath::root());
 
         let content = Box::new(Orientation::Vertical, 0);
         content.append(&HeaderBar::new());

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -17,8 +17,6 @@ pub fn run_app<T>(root: Root<T>) where T: View + 'static {
     app.connect_activate(move |app| {
         let node = Root::render(&root.lock());
         let node_widget = NodeWidget::root(node, clone!(root => move |id_path, event| {
-            // DEBUG
-            println!("Firing {:?} at {:?}", event, id_path);
             root.lock().fire_event(id_path, event);
         }));
 

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use adw::{gtk::{Box, Orientation}, prelude::*, Application, ApplicationWindow, HeaderBar};
 use node_widget::NodeWidget;
-use nuit_core::{IdPath, Root, View};
+use nuit_core::{Root, View};
 
 pub fn run_app<T>(root: Root<T>) where T: View + 'static {
     let root = Arc::new(Mutex::new(root));
@@ -14,7 +14,9 @@ pub fn run_app<T>(root: Root<T>) where T: View + 'static {
 
     app.connect_activate(move |app| {
         let node = Root::render(&mut root.lock().unwrap());
-        let node_widget = NodeWidget::from_node(node, IdPath::root());
+        let node_widget = NodeWidget::root(node, |id_path, event| {
+            // TODO: Handle event
+        });
 
         let content = Box::new(Orientation::Vertical, 0);
         content.append(&HeaderBar::new());

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -1,0 +1,20 @@
+use adw::{prelude::*, Application, ApplicationWindow};
+use nuit_core::{Root, View};
+
+pub fn run_app<T>(root: Root<T>) where T: View + 'static {
+    let app = Application::builder()
+        .application_id("com.example.NuitApp")
+        .build();
+
+    app.connect_activate(|app| {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Nuit App")
+            .default_width(640)
+            .default_height(480)
+            .build();
+        window.present();
+    });
+
+    app.run();
+}

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -2,7 +2,7 @@ mod node_widget;
 
 use std::sync::{Arc, Mutex};
 
-use adw::{gtk::{Box, ListBox, Orientation, SelectionMode}, prelude::*, ActionRow, Application, ApplicationWindow, HeaderBar};
+use adw::{gtk::{Box, Orientation}, prelude::*, Application, ApplicationWindow, HeaderBar};
 use node_widget::NodeWidget;
 use nuit_core::{Root, View};
 

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -1,4 +1,4 @@
-use adw::{prelude::*, Application, ApplicationWindow};
+use adw::{gtk::{Box, ListBox, Orientation, SelectionMode}, prelude::*, ActionRow, Application, ApplicationWindow, HeaderBar};
 use nuit_core::{Root, View};
 
 pub fn run_app<T>(root: Root<T>) where T: View + 'static {
@@ -7,11 +7,34 @@ pub fn run_app<T>(root: Root<T>) where T: View + 'static {
         .build();
 
     app.connect_activate(|app| {
+        let row = ActionRow::builder()
+            .activatable(true)
+            .title("Click me")
+            .build();
+        row.connect_activated(|_| {
+            eprintln!("Clicked!");
+        });
+
+        let list = ListBox::builder()
+            .margin_top(32)
+            .margin_end(32)
+            .margin_bottom(32)
+            .margin_start(32)
+            .selection_mode(SelectionMode::None)
+            .css_classes(vec!["boxed-list".to_owned()])
+            .build();
+        list.append(&row);
+
+        let content = Box::new(Orientation::Vertical, 0);
+        content.append(&HeaderBar::new());
+        content.append(&list);
+
         let window = ApplicationWindow::builder()
             .application(app)
             .title("Nuit App")
             .default_width(640)
             .default_height(480)
+            .content(&content)
             .build();
         window.present();
     });

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -1,3 +1,5 @@
+mod node_widget;
+
 use adw::{gtk::{Box, ListBox, Orientation, SelectionMode}, prelude::*, ActionRow, Application, ApplicationWindow, HeaderBar};
 use nuit_core::{Root, View};
 

--- a/nuit-bridge-adwaita/src/lib.rs
+++ b/nuit-bridge-adwaita/src/lib.rs
@@ -1,35 +1,24 @@
 mod node_widget;
 
+use std::sync::{Arc, Mutex};
+
 use adw::{gtk::{Box, ListBox, Orientation, SelectionMode}, prelude::*, ActionRow, Application, ApplicationWindow, HeaderBar};
+use node_widget::NodeWidget;
 use nuit_core::{Root, View};
 
 pub fn run_app<T>(root: Root<T>) where T: View + 'static {
+    let root = Arc::new(Mutex::new(root));
     let app = Application::builder()
         .application_id("com.example.NuitApp")
         .build();
 
-    app.connect_activate(|app| {
-        let row = ActionRow::builder()
-            .activatable(true)
-            .title("Click me")
-            .build();
-        row.connect_activated(|_| {
-            eprintln!("Clicked!");
-        });
-
-        let list = ListBox::builder()
-            .margin_top(32)
-            .margin_end(32)
-            .margin_bottom(32)
-            .margin_start(32)
-            .selection_mode(SelectionMode::None)
-            .css_classes(vec!["boxed-list".to_owned()])
-            .build();
-        list.append(&row);
+    app.connect_activate(move |app| {
+        let node = Root::render(&mut root.lock().unwrap());
+        let node_widget = NodeWidget::from(node);
 
         let content = Box::new(Orientation::Vertical, 0);
         content.append(&HeaderBar::new());
-        content.append(&list);
+        content.append(&node_widget);
 
         let window = ApplicationWindow::builder()
             .application(app)

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -8,23 +8,18 @@ use nuit_core::Node;
 // Object holding the state
 #[derive(Default)]
 pub struct NodeWidget {
-    node: Cell<Node>,
-}
-
-impl NodeWidget {
-    pub fn update(&self, node: Node) {
-        self.node.replace(node);
-        // TODO: Update widget
-    }
+    pub node: Cell<Node>,
 }
 
 #[glib::object_subclass]
 impl ObjectSubclass for NodeWidget {
     const NAME: &'static str = "NuitNodeWidget";
     type Type = super::NodeWidget;
-    type ParentType = gtk::Widget;
+    type ParentType = gtk::Box;
 }
 
 impl ObjectImpl for NodeWidget {}
 
 impl WidgetImpl for NodeWidget {}
+
+impl BoxImpl for NodeWidget {}

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -1,0 +1,23 @@
+use std::cell::Cell;
+
+use adw::{glib, gtk, subclass::prelude::*};
+use nuit_core::Node;
+
+// See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
+
+// Object holding the state
+#[derive(Default)]
+pub struct NodeWidget {
+    pub node: Cell<Node>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for NodeWidget {
+    const NAME: &'static str = "NuitNodeWidget";
+    type Type = super::NodeWidget;
+    type ParentType = gtk::Widget;
+}
+
+impl ObjectImpl for NodeWidget {}
+
+impl WidgetImpl for NodeWidget {}

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -8,7 +8,14 @@ use nuit_core::Node;
 // Object holding the state
 #[derive(Default)]
 pub struct NodeWidget {
-    pub node: Cell<Node>,
+    node: Cell<Node>,
+}
+
+impl NodeWidget {
+    pub fn update(&self, node: Node) {
+        self.node.replace(node);
+        // TODO: Update widget
+    }
 }
 
 #[glib::object_subclass]

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -1,7 +1,7 @@
-use std::cell::{Cell, RefCell};
+use std::{cell::{Cell, RefCell}, rc::Rc};
 
 use adw::{glib, gtk, subclass::prelude::*};
-use nuit_core::{IdPathBuf, Node};
+use nuit_core::{Event, IdPath, IdPathBuf, Node};
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
 
@@ -10,6 +10,7 @@ use nuit_core::{IdPathBuf, Node};
 pub struct NodeWidget {
     pub node: Cell<Node>,
     pub id_path: RefCell<IdPathBuf>,
+    pub fire_event: RefCell<Option<Rc<Box<dyn Fn(&IdPath, Event)>>>>,
 }
 
 #[glib::object_subclass]

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -10,7 +10,7 @@ use nuit_core::{Event, IdPath, IdPathBuf, Node};
 pub struct NodeWidget {
     pub node: Cell<Node>,
     pub id_path: RefCell<IdPathBuf>,
-    pub fire_event: RefCell<Option<Rc<Box<dyn Fn(&IdPath, Event)>>>>,
+    pub fire_event: RefCell<Option<Rc<Box<dyn Fn(&IdPath, &Event)>>>>,
 }
 
 #[glib::object_subclass]

--- a/nuit-bridge-adwaita/src/node_widget/imp.rs
+++ b/nuit-bridge-adwaita/src/node_widget/imp.rs
@@ -1,7 +1,7 @@
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use adw::{glib, gtk, subclass::prelude::*};
-use nuit_core::Node;
+use nuit_core::{IdPathBuf, Node};
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
 
@@ -9,6 +9,7 @@ use nuit_core::Node;
 #[derive(Default)]
 pub struct NodeWidget {
     pub node: Cell<Node>,
+    pub id_path: RefCell<IdPathBuf>,
 }
 
 #[glib::object_subclass]

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -60,14 +60,14 @@ impl NodeWidget {
             Node::HStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Horizontal, DEFAULT_SPACING);
                 for (child_path, child) in wrapped.value().children() {
-                    gtk_box.append(&NodeWidget::from_node(child.clone(), &id_path.descendant(&child_path)))
+                    gtk_box.append(&NodeWidget::from_node(child.clone(), &id_path.join(&child_path)))
                 }
                 self.append(&gtk_box);
             },
             Node::VStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Vertical, DEFAULT_SPACING);
                 for (child_path, child) in wrapped.value().children() {
-                    gtk_box.append(&NodeWidget::from_node(child.clone(), &id_path.descendant(&child_path)))
+                    gtk_box.append(&NodeWidget::from_node(child.clone(), &id_path.join(&child_path)))
                 }
                 self.append(&gtk_box);
             },

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -1,6 +1,6 @@
 mod imp;
 
-use adw::{glib::{self, Object}, gtk::{self, Button, Label, Orientation, Text}, prelude::BoxExt, subclass::prelude::*};
+use adw::{glib::{self, Object}, gtk::{self, Align, Button, Label, Orientation, Text}, prelude::{BoxExt, WidgetExt}, subclass::prelude::*};
 use nuit_core::Node;
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
@@ -14,7 +14,11 @@ glib::wrapper! {
 
 impl NodeWidget {
     pub fn new() -> Self {
-        Object::builder().build()
+        let widget: Self = Object::builder().build();
+        widget.set_halign(Align::Center);
+        widget.set_valign(Align::Center);
+        widget.set_vexpand(true);
+        widget
     }
 
     pub fn update(&self, node: Node) {

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -53,8 +53,6 @@ impl NodeWidget {
         let imp = imp::NodeWidget::from_obj(&self);
         imp.node.replace(node.clone());
 
-        let id_path = imp.id_path.borrow();
-
         match &node {
             Node::Empty {} => {},
             Node::Text { content } => {
@@ -69,21 +67,21 @@ impl NodeWidget {
                 let button = Button::new();
                 match label.value() {
                     Node::Text { content } => button.set_label(content),
-                    _ => button.set_child(Some(&self.child(label.value().clone(), &id_path.child(label.id().clone())))),
+                    _ => button.set_child(Some(&self.child(label.value().clone(), &IdPathBuf::from(label.id().clone())))),
                 }
                 self.append(&button);
             },
             Node::HStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Horizontal, DEFAULT_SPACING);
                 for (child_path, child) in wrapped.value().children() {
-                    gtk_box.append(&self.child(child.clone(), &id_path.join(&child_path)))
+                    gtk_box.append(&self.child(child.clone(), &child_path))
                 }
                 self.append(&gtk_box);
             },
             Node::VStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Vertical, DEFAULT_SPACING);
                 for (child_path, child) in wrapped.value().children() {
-                    gtk_box.append(&self.child(child.clone(), &id_path.join(&child_path)))
+                    gtk_box.append(&self.child(child.clone(), &child_path))
                 }
                 self.append(&gtk_box);
             },

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -1,26 +1,66 @@
 mod imp;
 
-use adw::{glib::{self, Object}, gtk, subclass::prelude::*};
+use adw::{glib::{self, Object}, gtk::{self, Button, Label, Orientation, Text}, prelude::BoxExt, subclass::prelude::*};
 use nuit_core::Node;
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
 
 glib::wrapper! {
     pub struct NodeWidget(ObjectSubclass<imp::NodeWidget>)
-        @extends gtk::Widget;
+        @extends gtk::Box, gtk::Widget;
 }
 
 impl NodeWidget {
     pub fn new() -> Self {
         Object::builder().build()
     }
+
+    pub fn update(&self, node: Node) {
+        // TODO: Diff node
+
+        match &node {
+            Node::Empty {} => {},
+            Node::Text { content } => {
+                let label = Label::new(Some(&content));
+                self.append(&label);
+            },
+            Node::TextField { content } => {
+                let text = Text::builder().text(content).build();
+                self.append(&text);
+            },
+            Node::Button { label } => match label.value() {
+                Node::Text { content } => {
+                    let button = Button::builder().label(content).build();
+                    self.append(&button);
+                },
+                _ => {}, // TODO: Handle non-text button labels
+            },
+            Node::HStack { wrapped } => {
+                let gtk_box = gtk::Box::new(Orientation::Horizontal, 0);
+                for (_, child) in wrapped.value().children() {
+                    gtk_box.append(&NodeWidget::from(child.clone()))
+                }
+                self.append(&gtk_box);
+            },
+            Node::VStack { wrapped } => {
+                let gtk_box = gtk::Box::new(Orientation::Vertical, 0);
+                for (_, child) in wrapped.value().children() {
+                    gtk_box.append(&NodeWidget::from(child.clone()))
+                }
+                self.append(&gtk_box);
+            },
+            _ => {}, // TODO: Handle other node types
+        }
+
+        let imp = imp::NodeWidget::from_obj(&self);
+        imp.node.replace(node);
+    }
 }
 
 impl From<Node> for NodeWidget {
     fn from(node: Node) -> Self {
-        let obj = Self::new();
-        let imp = imp::NodeWidget::from_obj(&obj);
-        imp.update(node);
-        obj
+        let widget = Self::new();
+        widget.update(node);
+        widget
     }
 }

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -1,0 +1,26 @@
+mod imp;
+
+use adw::{glib::{self, Object}, gtk, subclass::prelude::*};
+use nuit_core::Node;
+
+// See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
+
+glib::wrapper! {
+    pub struct NodeWidget(ObjectSubclass<imp::NodeWidget>)
+        @extends gtk::Widget;
+}
+
+impl NodeWidget {
+    pub fn new() -> Self {
+        Object::builder().build()
+    }
+}
+
+impl From<Node> for NodeWidget {
+    fn from(node: Node) -> Self {
+        let obj = Self::new();
+        let imp = imp::NodeWidget::from_obj(&obj);
+        imp.node.replace(node);
+        obj
+    }
+}

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -48,13 +48,17 @@ impl NodeWidget {
     }
 
     pub fn update(&self, node: Node) {
-        // TODO: Diff node
-
         let imp = imp::NodeWidget::from_obj(&self);
         imp.node.replace(node.clone());
 
         let id_path = imp.id_path.borrow();
         let fire_event = imp.fire_event.borrow();
+
+        // TODO: Diff nodes instead of replacing the entire tree
+
+        while let Some(child) = self.first_child() {
+            self.remove(&child);
+        }
 
         match &node {
             Node::Empty {} => {},

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -20,7 +20,7 @@ impl From<Node> for NodeWidget {
     fn from(node: Node) -> Self {
         let obj = Self::new();
         let imp = imp::NodeWidget::from_obj(&obj);
-        imp.node.replace(node);
+        imp.update(node);
         obj
     }
 }

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -1,6 +1,6 @@
 mod imp;
 
-use adw::{glib::{self, Object}, gtk::{self, Align, Button, Label, Orientation, Text}, prelude::{BoxExt, WidgetExt}, subclass::prelude::*};
+use adw::{glib::{self, Object}, gtk::{self, Align, Button, Label, Orientation, Text}, prelude::{BoxExt, ButtonExt, WidgetExt}, subclass::prelude::*};
 use nuit_core::{IdPath, Node};
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
@@ -50,12 +50,13 @@ impl NodeWidget {
                 let text = Text::builder().text(content).build();
                 self.append(&text);
             },
-            Node::Button { label } => match label.value() {
-                Node::Text { content } => {
-                    let button = Button::builder().label(content).build();
-                    self.append(&button);
-                },
-                _ => {}, // TODO: Handle non-text button labels
+            Node::Button { label } => {
+                let button = Button::new();
+                match label.value() {
+                    Node::Text { content } => button.set_label(content),
+                    _ => button.set_child(Some(&NodeWidget::from_node(label.value().clone(), &id_path.child(label.id().clone())))),
+                }
+                self.append(&button);
             },
             Node::HStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Horizontal, DEFAULT_SPACING);

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -5,6 +5,8 @@ use nuit_core::Node;
 
 // See https://gtk-rs.org/gtk4-rs/stable/latest/book/g_object_subclassing.html
 
+const DEFAULT_SPACING: i32 = 10;
+
 glib::wrapper! {
     pub struct NodeWidget(ObjectSubclass<imp::NodeWidget>)
         @extends gtk::Box, gtk::Widget;
@@ -36,14 +38,14 @@ impl NodeWidget {
                 _ => {}, // TODO: Handle non-text button labels
             },
             Node::HStack { wrapped } => {
-                let gtk_box = gtk::Box::new(Orientation::Horizontal, 0);
+                let gtk_box = gtk::Box::new(Orientation::Horizontal, DEFAULT_SPACING);
                 for (_, child) in wrapped.value().children() {
                     gtk_box.append(&NodeWidget::from(child.clone()))
                 }
                 self.append(&gtk_box);
             },
             Node::VStack { wrapped } => {
-                let gtk_box = gtk::Box::new(Orientation::Vertical, 0);
+                let gtk_box = gtk::Box::new(Orientation::Vertical, DEFAULT_SPACING);
                 for (_, child) in wrapped.value().children() {
                     gtk_box.append(&NodeWidget::from(child.clone()))
                 }

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -91,7 +91,6 @@ impl NodeWidget {
             Node::VStack { wrapped } => {
                 let gtk_box = gtk::Box::new(Orientation::Vertical, DEFAULT_SPACING);
                 for (child_path, child) in wrapped.value().children_from(&IdPathBuf::from(wrapped.id().clone())) {
-                    println!("{:?}", child_path);
                     gtk_box.append(&self.child(child.clone(), &child_path))
                 }
                 self.append(&gtk_box);

--- a/nuit-core/src/bind.rs
+++ b/nuit-core/src/bind.rs
@@ -2,7 +2,7 @@ use crate::Context;
 
 /// Binds a storage to the view's state.
 pub trait Bind {
-    fn bind(&mut self, _context: &Context) {
+    fn bind(&self, _context: &Context) {
         // Bind nothing by default
     }
 }

--- a/nuit-core/src/compose/shape/shape.rs
+++ b/nuit-core/src/compose/shape/shape.rs
@@ -9,7 +9,7 @@ pub trait Shape {
     }
 
     fn render(&self) -> ShapeNode {
-        self.body().render()
+        Shape::render(&self.body())
     }
 }
 
@@ -23,7 +23,7 @@ impl<T> Bind for T where T: Shape {}
 impl<T> View for T where T: Shape {
     fn fire(&self, _event: &Event, _id_path: &IdPath) {}
 
-    fn render(&mut self, _context: &Context) -> Node {
+    fn render(&self, _context: &Context) -> Node {
         Node::Shape {
             shape: Shape::render(self)
         }

--- a/nuit-core/src/compose/view/aggregation/for_each.rs
+++ b/nuit-core/src/compose/view/aggregation/for_each.rs
@@ -57,7 +57,7 @@ where
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::Group {
             children: self.collection
                 .into_iter()

--- a/nuit-core/src/compose/view/aggregation/if.rs
+++ b/nuit-core/src/compose/view/aggregation/if.rs
@@ -47,10 +47,10 @@ impl<T, F> View for If<T, F> where T: View, F: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
-        if let Some(ref mut then_view) = self.then_view {
+    fn render(&self, context: &Context) -> Node {
+        if let Some(ref then_view) = self.then_view {
             Node::Child { wrapped: Box::new(then_view.render(&context.child(0)).identify(0)) }
-        } else if let Some(ref mut else_view) = self.else_view {
+        } else if let Some(ref else_view) = self.else_view {
             Node::Child { wrapped: Box::new(else_view.render(&context.child(1)).identify(1)) }
         } else {
             Node::Empty {}

--- a/nuit-core/src/compose/view/event/handler.rs
+++ b/nuit-core/src/compose/view/event/handler.rs
@@ -26,7 +26,7 @@ impl<T, F> View for Handler<T, F> where T: View, F: Fn(Event) {
         self.wrapped.fire(event, id_path);
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         self.wrapped.render(&context)
     }
 }

--- a/nuit-core/src/compose/view/layout/h_stack.rs
+++ b/nuit-core/src/compose/view/layout/h_stack.rs
@@ -26,7 +26,7 @@ impl<T> View for HStack<T> where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::HStack { wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/layout/list.rs
+++ b/nuit-core/src/compose/view/layout/list.rs
@@ -26,7 +26,7 @@ impl<T> View for List<T> where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::List { wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/layout/v_stack.rs
+++ b/nuit-core/src/compose/view/layout/v_stack.rs
@@ -26,7 +26,7 @@ impl<T> View for VStack<T> where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::VStack { wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/layout/z_stack.rs
+++ b/nuit-core/src/compose/view/layout/z_stack.rs
@@ -26,7 +26,7 @@ impl<T> View for ZStack<T> where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::ZStack { wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/view.rs
+++ b/nuit-core/src/compose/view/view.rs
@@ -14,7 +14,7 @@ pub trait View: Bind {
         self.body().fire(event, id_path);
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         self.bind(context);
         self.body().render(context)
     }
@@ -32,7 +32,7 @@ macro_rules! impl_tuple_view {
                 }
             }
 
-            fn render(&mut self, context: &Context) -> Node {
+            fn render(&self, context: &Context) -> Node {
                 Node::Group {
                     children: vec![
                         $(${ignore($tvs)} self.${index()}.render(&context.child(${index()})).identify(${index()}),)*
@@ -55,7 +55,7 @@ impl View for NeverView {}
 impl View for () {
     fn fire(&self, _event: &Event, _id_path: &IdPath) {}
 
-    fn render(&mut self, _context: &Context) -> Node {
+    fn render(&self, _context: &Context) -> Node {
         Node::Empty {}
     }
 }
@@ -76,7 +76,7 @@ impl<T> View for (T,) where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::Child { wrapped: Box::new(self.0.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/widget/button.rs
+++ b/nuit-core/src/compose/view/widget/button.rs
@@ -32,7 +32,7 @@ impl<T, F> View for Button<T, F> where T: View, F: Fn() + 'static {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::Button { label: Box::new(self.label.render(&context.child(0)).identify(0)) }
     }
 }

--- a/nuit-core/src/compose/view/widget/picker.rs
+++ b/nuit-core/src/compose/view/widget/picker.rs
@@ -24,7 +24,7 @@ impl<C> View for Picker<C> where C: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::Picker {
             title: self.title.clone(),
             selection: self.selection.get(),

--- a/nuit-core/src/compose/view/widget/text.rs
+++ b/nuit-core/src/compose/view/widget/text.rs
@@ -19,7 +19,7 @@ impl Bind for Text {}
 impl View for Text {
     fn fire(&self, _event: &Event, _id_path: &IdPath) {}
 
-    fn render(&mut self, _context: &Context) -> Node {
+    fn render(&self, _context: &Context) -> Node {
         Node::Text { content: self.content.clone() }
     }
 }

--- a/nuit-core/src/compose/view/widget/text_field.rs
+++ b/nuit-core/src/compose/view/widget/text_field.rs
@@ -22,7 +22,7 @@ impl View for TextField {
         }
     }
 
-    fn render(&mut self, _context: &Context) -> Node {
+    fn render(&self, _context: &Context) -> Node {
         Node::TextField { content: self.content.get() }
     }
 }

--- a/nuit-core/src/compose/view/wrapper/modified.rs
+++ b/nuit-core/src/compose/view/wrapper/modified.rs
@@ -28,7 +28,7 @@ impl<T> View for Modified<T> where T: View {
         }
     }
 
-    fn render(&mut self, context: &Context) -> Node {
+    fn render(&self, context: &Context) -> Node {
         Node::Modified {
             wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0)),
             modifier: self.modifier,

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Deserialize};
 
-use crate::{Id, Identified};
+use crate::{Id, IdPath, IdPathBuf, Identified};
 
 use super::{ModifierNode, ShapeNode};
 
@@ -29,6 +29,21 @@ pub enum Node {
     // Wrapper
     Shape { shape: ShapeNode },
     Modified { wrapped: Box<Identified<Node>>, modifier: ModifierNode, }
+}
+
+impl Node {
+    pub fn children(&self) -> Vec<(IdPathBuf, &Node)> {
+        self.children_from(IdPath::root())
+    }
+
+    fn children_from(&self, path: &IdPath) -> Vec<(IdPathBuf, &Node)> {
+        match self {
+            Self::Group { children } => children.iter()
+                .flat_map(|c| c.value().children_from(&path.child(c.id().clone())).into_iter())
+                .collect(),
+            _ => vec![(IdPathBuf::root(), self)]
+        }
+    }
 }
 
 impl Default for Node {

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -30,3 +30,9 @@ pub enum Node {
     Shape { shape: ShapeNode },
     Modified { wrapped: Box<Identified<Node>>, modifier: ModifierNode, }
 }
+
+impl Default for Node {
+    fn default() -> Self {
+        Node::Empty {}
+    }
+}

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -36,12 +36,12 @@ impl Node {
         self.children_from(IdPath::root())
     }
 
-    fn children_from(&self, path: &IdPath) -> Vec<(IdPathBuf, &Node)> {
+    pub fn children_from(&self, path: &IdPath) -> Vec<(IdPathBuf, &Node)> {
         match self {
             Self::Group { children } => children.iter()
                 .flat_map(|c| c.value().children_from(&path.child(c.id().clone())).into_iter())
                 .collect(),
-            _ => vec![(IdPathBuf::root(), self)]
+            _ => vec![(path.to_owned(), self)]
         }
     }
 }

--- a/nuit-core/src/root.rs
+++ b/nuit-core/src/root.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{Storage, Node, View, Context, Event, IdPathBuf, NodeDiff};
+use crate::{Context, Event, IdPath, IdPathBuf, Node, NodeDiff, Storage, View};
 
 /// The central state of a Nuit application.
 pub struct Root<T> {
@@ -53,7 +53,11 @@ impl<T> Root<T> where T: View {
     pub fn fire_event_json(&mut self, id_path_json: &str, event_json: &str) {
         let id_path: IdPathBuf = serde_json::from_str(id_path_json).expect("Could not deserialize id path");
         let event: Event = serde_json::from_str(event_json).expect("Could not deserialize event");
-        self.view.fire(&event, &id_path);
+        self.fire_event(&id_path, &event);
+    }
+
+    pub fn fire_event(&mut self, id_path: &IdPath, event: &Event) {
+        self.view.fire(event, id_path);
     }
 
     pub fn set_update_callback(&mut self, update_callback: impl Fn() + 'static) {

--- a/nuit-core/src/root.rs
+++ b/nuit-core/src/root.rs
@@ -1,20 +1,20 @@
-use std::rc::Rc;
+use std::{cell::RefCell, rc::Rc};
 
 use crate::{Context, Event, IdPath, IdPathBuf, Node, NodeDiff, Storage, View};
 
 /// The central state of a Nuit application.
 pub struct Root<T> {
-    view: T,
+    view: RefCell<T>,
     storage: Rc<Storage>,
-    last_render: Node,
+    last_render: RefCell<Node>,
 }
 
 impl<T> Root<T> {
     pub fn new(view: T) -> Self {
         Self {
-            view,
+            view: RefCell::new(view),
             storage: Rc::new(Storage::new()),
-            last_render: Node::Empty {},
+            last_render: RefCell::new(Node::Empty {}),
         }
     }
 
@@ -24,43 +24,43 @@ impl<T> Root<T> {
 }
 
 impl<T> Root<T> where T: View {
-    pub fn render(&mut self) -> Node {
+    pub fn render(&self) -> Node {
         let new_render = self.storage.with_preapplied_changes(|| {
-            self.view.render(&Context::new(self.storage.clone()))
+            self.view.borrow().render(&Context::new(self.storage.clone()))
         });
 
-        let diff = NodeDiff::between(&new_render, &self.last_render);
+        let diff = NodeDiff::between(&new_render, &self.last_render.borrow());
 
         for id_path in diff.removed() {
-            self.view.fire(&Event::Disappear, id_path)
+            self.view.borrow().fire(&Event::Disappear, id_path)
         }
 
         self.storage.apply_changes();
 
         for id_path in diff.added() {
-            self.view.fire(&Event::Appear, id_path)
+            self.view.borrow().fire(&Event::Appear, id_path)
         }
 
-        self.last_render = new_render.clone();
+        *self.last_render.borrow_mut() = new_render.clone();
         new_render
     }
 
-    pub fn render_json(&mut self) -> String {
+    pub fn render_json(&self) -> String {
         let node = self.render();
         serde_json::to_string(&node).expect("Could not serialize view")
     }
 
-    pub fn fire_event_json(&mut self, id_path_json: &str, event_json: &str) {
+    pub fn fire_event_json(&self, id_path_json: &str, event_json: &str) {
         let id_path: IdPathBuf = serde_json::from_str(id_path_json).expect("Could not deserialize id path");
         let event: Event = serde_json::from_str(event_json).expect("Could not deserialize event");
         self.fire_event(&id_path, &event);
     }
 
-    pub fn fire_event(&mut self, id_path: &IdPath, event: &Event) {
-        self.view.fire(event, id_path);
+    pub fn fire_event(&self, id_path: &IdPath, event: &Event) {
+        self.view.borrow().fire(event, id_path);
     }
 
-    pub fn set_update_callback(&mut self, update_callback: impl Fn() + 'static) {
+    pub fn set_update_callback(&self, update_callback: impl Fn() + 'static) {
         self.storage.set_update_callback(update_callback);
     }
 }

--- a/nuit-core/src/utils/clone.rs
+++ b/nuit-core/src/utils/clone.rs
@@ -8,4 +8,10 @@ macro_rules! clone {
             move || $body
         }
     );
+    ($($n:ident),+ => move |$($i:ident),*| $body:expr) => (
+        {
+            $( let $n = $n.clone(); )+
+            move |$($i,)*| $body
+        }
+    );
 }

--- a/nuit-core/src/utils/id_path.rs
+++ b/nuit-core/src/utils/id_path.rs
@@ -72,6 +72,12 @@ impl Default for IdPathBuf {
     }
 }
 
+impl From<Id> for IdPathBuf {
+    fn from(id: Id) -> Self {
+        Self(vec![id])
+    }
+}
+
 impl Deref for IdPathBuf {
     type Target = IdPath;
 

--- a/nuit-core/src/utils/id_path.rs
+++ b/nuit-core/src/utils/id_path.rs
@@ -35,8 +35,8 @@ impl IdPath {
         self.to_owned().child(id)
     }
 
-    pub fn descendant(&self, path: &IdPath) -> IdPathBuf {
-        self.to_owned().descendant(path)
+    pub fn join(&self, path: &IdPath) -> IdPathBuf {
+        self.to_owned().join(path)
     }
 }
 
@@ -51,7 +51,7 @@ impl IdPathBuf {
         Self(components)
     }
 
-    pub fn descendant(&self, path: &IdPath) -> Self {
+    pub fn join(&self, path: &IdPath) -> Self {
         let mut components = self.0.clone();
         components.extend(path.0.into_iter().cloned());
         Self(components)

--- a/nuit-core/src/utils/id_path.rs
+++ b/nuit-core/src/utils/id_path.rs
@@ -56,6 +56,12 @@ impl ToOwned for IdPath {
     }
 }
 
+impl Default for IdPathBuf {
+    fn default() -> Self {
+        Self::root()
+    }
+}
+
 impl Deref for IdPathBuf {
     type Target = IdPath;
 

--- a/nuit-core/src/utils/id_path.rs
+++ b/nuit-core/src/utils/id_path.rs
@@ -34,6 +34,10 @@ impl IdPath {
     pub fn child(&self, id: impl Into<Id>) -> IdPathBuf {
         self.to_owned().child(id)
     }
+
+    pub fn descendant(&self, path: &IdPath) -> IdPathBuf {
+        self.to_owned().descendant(path)
+    }
 }
 
 impl IdPathBuf {
@@ -44,6 +48,12 @@ impl IdPathBuf {
     pub fn child(&self, id: impl Into<Id>) -> Self {
         let mut components = self.0.clone();
         components.push(id.into());
+        Self(components)
+    }
+
+    pub fn descendant(&self, path: &IdPath) -> Self {
+        let mut components = self.0.clone();
+        components.extend(path.0.into_iter().cloned());
         Self(components)
     }
 }

--- a/nuit-core/src/utils/id_path.rs
+++ b/nuit-core/src/utils/id_path.rs
@@ -15,6 +15,10 @@ pub struct IdPath([Id]);
 pub struct IdPathBuf(Vec<Id>);
 
 impl IdPath {
+    pub fn root() -> &'static Self {
+        Self::ref_cast(&[])
+    }
+
     pub fn is_root(&self) -> bool {
         self.0.is_empty()
     }

--- a/nuit-derive/src/lib.rs
+++ b/nuit-derive/src/lib.rs
@@ -24,7 +24,7 @@ pub fn derive_bind(input: TokenStream) -> TokenStream {
     // TODO: Handle generic structs
     let impl_block = quote! {
         impl ::nuit::Bind for #name {
-            fn bind(&mut self, context: &::nuit::Context) {
+            fn bind(&self, context: &::nuit::Context) {
                 #(self.#state_fields.link(context.storage().clone(), context.id_path(), #indices);)*
             }
         }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,6 @@
 /// A UI backend.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Backend {
+    Adwaita,
     SwiftUI,
-    Relm,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ impl Default for Backend {
         #[cfg(target_vendor = "apple")]
         return Backend::SwiftUI;
         #[cfg(not(target_vendor = "apple"))]
-        return Backend::Relm;
+        return Backend::Adwaita;
     }
 }
 
@@ -31,7 +31,7 @@ pub fn run_app<T>(config: impl Into<Config<T>>) where T: View {
             #[cfg(not(target_vendor = "apple"))]
             panic!("SwiftUI is not supported outside of Apple platforms!")
         }
-        Backend::Relm => {
+        Backend::Adwaita => {
             panic!("Relm is not supported (yet)")
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ impl Default for Backend {
 }
 
 /// Blocks and presents the given view to the user.
-pub fn run_app<T>(config: impl Into<Config<T>>) where T: View {
+pub fn run_app<T>(config: impl Into<Config<T>>) where T: View + 'static {
     let config: Config<T> = config.into();
     let backend = config.preferred_backend().unwrap_or_default();
     let view = config.into_view();
@@ -32,7 +32,7 @@ pub fn run_app<T>(config: impl Into<Config<T>>) where T: View {
             panic!("SwiftUI is not supported outside of Apple platforms!")
         }
         Backend::Adwaita => {
-            panic!("Relm is not supported (yet)")
+            nuit_bridge_adwaita::run_app(root);
         }
     }
 }


### PR DESCRIPTION
### Fixes #7 and supersedes #4 

This adds a Libadwaita/GTK4 backend for Nuit. Libadwaita/GNOME use a similar design language to many idioms found in SwiftUI, so the impedance mismatch in terms of UI widgets shouldn't be that big.

![image](https://github.com/user-attachments/assets/3e6efd96-5745-491c-a50c-380de28349a5)
