### PR TITLE
Add support for composable gestures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,17 @@ license.workspace = true
 default = ["adwaita", "swiftui"]
 adwaita = ["dep:nuit-bridge-adwaita"]
 swiftui = ["dep:nuit-bridge-swiftui"]
+rand = ["nuit-core/rand"]
 
 [dependencies]
 nuit-derive.workspace = true
 nuit-core.workspace = true
 nuit-bridge-adwaita = { workspace = true, optional = true }
 nuit-bridge-swiftui = { workspace = true, optional = true }
+
+[[example]]
+name = "gestures"
+required-features = ["rand"]
 
 [workspace]
 members = [

--- a/examples/gestures.rs
+++ b/examples/gestures.rs
@@ -1,21 +1,23 @@
 #![feature(type_alias_impl_trait, impl_trait_in_assoc_type)]
 
-use nuit::{Bind, Circle, Color, ShapeExt, State, Text, View, ViewExt};
+use nuit::{Bind, Circle, Color, HStack, ShapeExt, State, Text, View, ViewExt};
 
 #[derive(Bind)]
-struct GesturesView {
+struct TapView {
+    taps: usize,
     color: State<Color>,
 }
 
-impl GesturesView {
-    pub fn new() -> Self {
+impl TapView {
+    pub fn new(taps: usize) -> Self {
         Self {
+            taps,
             color: State::new(Color::BLACK),
         }
     }
 }
 
-impl View for GesturesView {
+impl View for TapView {
     type Body = impl View;
 
     fn body(&self) -> Self::Body {
@@ -24,12 +26,26 @@ impl View for GesturesView {
             .fill(color.get())
             .frame(100)
             .overlay(Text::new("Tap me!"))
-            .on_tap(move || {
+            .on_taps(self.taps, move || {
                 color.set(Color::random_rgb());
             })
     }
 }
 
+#[derive(Bind)]
+struct GesturesView;
+
+impl View for GesturesView {
+    type Body = impl View;
+
+    fn body(&self) -> Self::Body {
+        HStack::new((
+            TapView::new(1),
+            TapView::new(2),
+        ))
+    }
+}
+
 fn main() {
-    nuit::run_app(GesturesView::new());
+    nuit::run_app(GesturesView);
 }

--- a/examples/gestures.rs
+++ b/examples/gestures.rs
@@ -1,0 +1,34 @@
+#![feature(type_alias_impl_trait, impl_trait_in_assoc_type)]
+
+use nuit::{Bind, Circle, Color, ShapeExt, State, Text, View, ViewExt};
+
+#[derive(Bind)]
+struct GesturesView {
+    color: State<Color>,
+}
+
+impl GesturesView {
+    pub fn new() -> Self {
+        Self {
+            color: State::new(Color::BLACK),
+        }
+    }
+}
+
+impl View for GesturesView {
+    type Body = impl View;
+
+    fn body(&self) -> Self::Body {
+        let color = self.color.clone();
+        Circle::new()
+            .fill(color.get())
+            .overlay(Text::new("Tap me!"))
+            .on_tap(move || {
+                color.set(Color::random_rgb());
+            })
+    }
+}
+
+fn main() {
+    nuit::run_app(GesturesView::new());
+}

--- a/examples/gestures.rs
+++ b/examples/gestures.rs
@@ -22,6 +22,7 @@ impl View for GesturesView {
         let color = self.color.clone();
         Circle::new()
             .fill(color.get())
+            .frame(100)
             .overlay(Text::new("Tap me!"))
             .on_tap(move || {
                 color.set(Color::random_rgb());

--- a/nuit-bridge-adwaita/src/node_widget/mod.rs
+++ b/nuit-bridge-adwaita/src/node_widget/mod.rs
@@ -93,7 +93,7 @@ impl NodeWidget {
                 }
                 if let Some(ref fire_event) = *fire_event {
                     button.connect_clicked(clone!(fire_event, id_path => move |_button| {
-                        fire_event(&id_path, &Event::Click {});
+                        fire_event(&id_path, &Event::ButtonTap {});
                     }));
                 }
                 self.append(&button);

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event.swift
@@ -1,5 +1,5 @@
 enum Event: Codable, Hashable {
-    case click
+    case buttonTap
     case gesture(gesture: GestureEvent)
     case updateText(content: String)
     case updatePickerSelection(id: Id)

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event.swift
@@ -1,5 +1,6 @@
 enum Event: Codable, Hashable {
     case click
+    case gesture(gesture: GestureEvent)
     case updateText(content: String)
     case updatePickerSelection(id: Id)
 }

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureEvent.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureEvent.swift
@@ -1,0 +1,3 @@
+enum GestureEvent: Codable, Hashable {
+    case tap
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNode.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNode.swift
@@ -1,0 +1,3 @@
+enum GestureNode: Codable, Hashable {
+    case tap
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNode.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNode.swift
@@ -1,3 +1,3 @@
 enum GestureNode: Codable, Hashable {
-    case tap
+    case tap(count: Int)
 }

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNodeGesture.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNodeGesture.swift
@@ -8,8 +8,8 @@ struct GestureNodeGesture: Gesture {
 
     var body: some Gesture {
         switch node {
-        case .tap:
-            TapGesture()
+        case let .tap(count: count):
+            TapGesture(count: count)
                 .onEnded { _ in root.fire(event: .gesture(gesture: .tap), for: idPath) }
         }
     }

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNodeGesture.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/GestureNodeGesture.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct GestureNodeGesture: Gesture {
+    let node: GestureNode
+    let idPath: [Id]
+
+    @EnvironmentObject private var root: Root
+
+    var body: some Gesture {
+        switch node {
+        case .tap:
+            TapGesture()
+                .onEnded { _ in root.fire(event: .gesture(gesture: .tap), for: idPath) }
+        }
+    }
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
@@ -20,5 +20,6 @@ indirect enum Node: Codable, Hashable {
 
     // MARK: Wrapper
     case shape(shape: ShapeNode)
+    case gestured(wrapped: Identified<Node>, gesture: Identified<GestureNode>)
     case modified(wrapped: Identified<Node>, modifier: ModifierNode)
 }

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
@@ -23,7 +23,7 @@ struct NodeView: View {
             }
         case let .button(label: label):
             Button {
-                root.fire(event: .click, for: idPath)
+                root.fire(event: .buttonTap, for: idPath)
             } label: {
                 NodeView(node: label.value, idPath: idPath + [label.id])
             }

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
@@ -70,6 +70,9 @@ struct NodeView: View {
         // MARK: Wrapper
         case let .shape(shape: shape):
             ShapeNodeView(shape: shape)
+        case let .gestured(wrapped: wrapped, gesture: gesture):
+            NodeView(node: wrapped.value, idPath: idPath + [wrapped.id])
+                .gesture(GestureNodeGesture(node: gesture.value, idPath: idPath + [gesture.id]))
         case let .modified(wrapped: wrapped, modifier: modifier):
             NodeView(node: wrapped.value, idPath: idPath + [wrapped.id])
                 .modifier(ModifierNodeViewModifier(modifier: modifier))

--- a/nuit-core/Cargo.toml
+++ b/nuit-core/Cargo.toml
@@ -10,4 +10,5 @@ license.workspace = true
 nuit-derive.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+rand = "0.8"
 ref-cast = "1.0"

--- a/nuit-core/Cargo.toml
+++ b/nuit-core/Cargo.toml
@@ -6,9 +6,13 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 
+[features]
+default = []
+rand = ["dep:rand"]
+
 [dependencies]
 nuit-derive.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-rand = "0.8"
+rand = { version = "0.8", optional = true }
 ref-cast = "1.0"

--- a/nuit-core/src/compose/gesture/gesture.rs
+++ b/nuit-core/src/compose/gesture/gesture.rs
@@ -1,0 +1,23 @@
+use crate::{GestureEvent, GestureNode, IdPath};
+
+/// A composable gesture.
+pub trait Gesture {
+    type Body: Gesture = NeverGesture;
+
+    fn body(&self) -> Self::Body {
+        panic!("Gesture does not have a body!")
+    }
+
+    fn fire(&self, event: &GestureEvent, id_path: &IdPath) {
+        self.body().fire(event, id_path)
+    }
+
+    fn render(&self) -> GestureNode {
+        Gesture::render(&self.body())
+    }
+}
+
+/// A gesture type that can never be constructed.
+pub enum NeverGesture {}
+
+impl Gesture for NeverGesture {}

--- a/nuit-core/src/compose/gesture/gesture.rs
+++ b/nuit-core/src/compose/gesture/gesture.rs
@@ -1,7 +1,7 @@
-use crate::{GestureEvent, GestureNode, IdPath};
+use crate::{Bind, Context, GestureEvent, GestureNode, IdPath};
 
 /// A composable gesture.
-pub trait Gesture {
+pub trait Gesture: Bind {
     type Body: Gesture = NeverGesture;
 
     fn body(&self) -> Self::Body {
@@ -12,12 +12,14 @@ pub trait Gesture {
         self.body().fire(event, id_path)
     }
 
-    fn render(&self) -> GestureNode {
-        Gesture::render(&self.body())
+    fn render(&self, context: &Context) -> GestureNode {
+        self.bind(context);
+        self.body().render(context)
     }
 }
 
 /// A gesture type that can never be constructed.
 pub enum NeverGesture {}
 
+impl Bind for NeverGesture {}
 impl Gesture for NeverGesture {}

--- a/nuit-core/src/compose/gesture/mod.rs
+++ b/nuit-core/src/compose/gesture/mod.rs
@@ -1,0 +1,5 @@
+mod gesture;
+mod tap;
+
+pub use gesture::*;
+pub use tap::*;

--- a/nuit-core/src/compose/gesture/tap.rs
+++ b/nuit-core/src/compose/gesture/tap.rs
@@ -1,0 +1,18 @@
+use crate::{Gesture, GestureNode};
+
+/// A gesture recognizing a tap.
+pub struct TapGesture<F> {
+    action: F,
+}
+
+impl<F> TapGesture<F> {
+    pub fn new(action: F) -> Self {
+        Self { action }
+    }
+}
+
+impl<F> Gesture for TapGesture<F> where F: Fn() {
+    fn render(&self) -> GestureNode {
+        GestureNode::Tap {}
+    }
+}

--- a/nuit-core/src/compose/gesture/tap.rs
+++ b/nuit-core/src/compose/gesture/tap.rs
@@ -1,6 +1,9 @@
-use crate::{Gesture, GestureNode};
+use nuit_derive::Bind;
+
+use crate::{Context, Gesture, GestureEvent, GestureNode, IdPath};
 
 /// A gesture recognizing a tap.
+#[derive(Bind)]
 pub struct TapGesture<F> {
     action: F,
 }
@@ -12,7 +15,15 @@ impl<F> TapGesture<F> {
 }
 
 impl<F> Gesture for TapGesture<F> where F: Fn() {
-    fn render(&self) -> GestureNode {
+    fn fire(&self, event: &GestureEvent, id_path: &IdPath) {
+        if let GestureEvent::Tap {} = event {
+            (self.action)();
+        } else {
+            eprintln!("Warning: Ignoring non-tap gesture event {:?} targeted to TapGesture at {:?}", event, id_path)
+        }
+    }
+
+    fn render(&self, _context: &Context) -> GestureNode {
         GestureNode::Tap {}
     }
 }

--- a/nuit-core/src/compose/gesture/tap.rs
+++ b/nuit-core/src/compose/gesture/tap.rs
@@ -5,12 +5,21 @@ use crate::{Context, Gesture, GestureEvent, GestureNode, IdPath};
 /// A gesture recognizing a tap.
 #[derive(Bind)]
 pub struct TapGesture<F> {
+    count: usize,
     action: F,
 }
 
 impl<F> TapGesture<F> {
-    pub fn new(action: F) -> Self {
-        Self { action }
+    /// Creates a tap gesture that executes the given action upon recognizing
+    /// the given number of taps.
+    pub fn new(count: usize, action: F) -> Self {
+        Self { count, action }
+    }
+
+    /// Creates a tap gesture that executes the given action after recognizing a
+    /// single tap.
+    pub fn new_single(action: F) -> Self {
+        Self::new(1, action)
     }
 }
 
@@ -24,6 +33,6 @@ impl<F> Gesture for TapGesture<F> where F: Fn() {
     }
 
     fn render(&self, _context: &Context) -> GestureNode {
-        GestureNode::Tap {}
+        GestureNode::Tap { count: self.count }
     }
 }

--- a/nuit-core/src/compose/mod.rs
+++ b/nuit-core/src/compose/mod.rs
@@ -1,9 +1,11 @@
 mod bind;
 mod defaults;
+mod gesture;
 mod shape;
 mod view;
 
 pub use bind::*;
 pub use defaults::*;
+pub use gesture::*;
 pub use shape::*;
 pub use view::*;

--- a/nuit-core/src/compose/view/ext.rs
+++ b/nuit-core/src/compose/view/ext.rs
@@ -1,11 +1,19 @@
-use crate::{Alignment, Event, Frame, Handler, Insets, Modified, ModifierNode, Vec2, View};
+use crate::{Alignment, Event, Frame, Handler, Insets, Modified, ModifierNode, TapGesture, Vec2, View};
 
-use super::Overlay;
+use super::{Gestured, Overlay};
 
 /// An extension trait with various convenience methods for views.
 pub trait ViewExt: Sized {
     fn modifier(self, modifier: ModifierNode) -> Modified<Self> {
         Modified::new(self, modifier)
+    }
+
+    fn gesture<G>(self, gesture: G) -> Gestured<Self, G> {
+        Gestured::new(self, gesture)
+    }
+
+    fn on_tap<F>(self, action: F) -> Gestured<Self, TapGesture<F>> {
+        self.gesture(TapGesture::new(action))
     }
 
     fn overlay_at<O>(self, alignment: Alignment, overlayed: O) -> Overlay<Self, O> {

--- a/nuit-core/src/compose/view/ext.rs
+++ b/nuit-core/src/compose/view/ext.rs
@@ -12,8 +12,12 @@ pub trait ViewExt: Sized {
         Gestured::new(self, gesture)
     }
 
+    fn on_taps<F>(self, count: usize, action: F) -> Gestured<Self, TapGesture<F>> {
+        self.gesture(TapGesture::new(count, action))
+    }
+
     fn on_tap<F>(self, action: F) -> Gestured<Self, TapGesture<F>> {
-        self.gesture(TapGesture::new_single(action))
+        self.on_taps(1, action)
     }
 
     fn overlay_at<O>(self, alignment: Alignment, overlayed: O) -> Overlay<Self, O> {

--- a/nuit-core/src/compose/view/ext.rs
+++ b/nuit-core/src/compose/view/ext.rs
@@ -13,7 +13,7 @@ pub trait ViewExt: Sized {
     }
 
     fn on_tap<F>(self, action: F) -> Gestured<Self, TapGesture<F>> {
-        self.gesture(TapGesture::new(action))
+        self.gesture(TapGesture::new_single(action))
     }
 
     fn overlay_at<O>(self, alignment: Alignment, overlayed: O) -> Overlay<Self, O> {

--- a/nuit-core/src/compose/view/widget/button.rs
+++ b/nuit-core/src/compose/view/widget/button.rs
@@ -25,7 +25,7 @@ impl<T, F> View for Button<T, F> where T: View, F: Fn() + 'static {
                 Id::Index(0) => self.label.fire(event, &id_path.tail()),
                 i => panic!("Cannot fire event for child id {} on Button which only has one child", i)
             }
-        } else if let Event::Click {} = event {
+        } else if let Event::ButtonTap {} = event {
             if let Some(ref action) = self.action {
                 action();
             }

--- a/nuit-core/src/compose/view/wrapper/mod.rs
+++ b/nuit-core/src/compose/view/wrapper/mod.rs
@@ -1,3 +1,5 @@
+mod gestured;
 mod modified;
 
+pub use gestured::*;
 pub use modified::*;

--- a/nuit-core/src/event/event.rs
+++ b/nuit-core/src/event/event.rs
@@ -9,7 +9,7 @@ use super::GestureEvent;
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum Event {
     // Interaction
-    Click {},
+    ButtonTap {},
     Gesture { gesture: GestureEvent },
     UpdateText { content: String },
     UpdatePickerSelection { id: Id },

--- a/nuit-core/src/event/event.rs
+++ b/nuit-core/src/event/event.rs
@@ -2,12 +2,15 @@ use serde::{Serialize, Deserialize};
 
 use crate::Id;
 
+use super::GestureEvent;
+
 /// A UI event.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum Event {
     // Interaction
     Click {},
+    Gesture { gesture: GestureEvent },
     UpdateText { content: String },
     UpdatePickerSelection { id: Id },
 

--- a/nuit-core/src/event/gesture.rs
+++ b/nuit-core/src/event/gesture.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+/// A gesture-related UI event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum GestureEvent {
+    Tap {},
+}

--- a/nuit-core/src/event/mod.rs
+++ b/nuit-core/src/event/mod.rs
@@ -1,0 +1,5 @@
+mod event;
+mod gesture;
+
+pub use event::*;
+pub use gesture::*;

--- a/nuit-core/src/node/gesture.rs
+++ b/nuit-core/src/node/gesture.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+/// A rendered gesture tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum GestureNode {
+    Tap {},
+}

--- a/nuit-core/src/node/gesture.rs
+++ b/nuit-core/src/node/gesture.rs
@@ -4,5 +4,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum GestureNode {
-    Tap {},
+    Tap { count: usize },
 }

--- a/nuit-core/src/node/mod.rs
+++ b/nuit-core/src/node/mod.rs
@@ -1,7 +1,9 @@
+mod gesture;
 mod modifier;
 mod node;
 mod shape;
 
+pub use gesture::*;
 pub use modifier::*;
 pub use node::*;
 pub use shape::*;

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -30,7 +30,7 @@ pub enum Node {
 
     // Wrapper
     Shape { shape: ShapeNode },
-    Gesture { wrapped: Box<Identified<Node>>, gesture: GestureNode, },
+    Gestured { wrapped: Box<Identified<Node>>, gesture: Identified<GestureNode>, },
     Modified { wrapped: Box<Identified<Node>>, modifier: ModifierNode, }
 }
 

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -3,7 +3,7 @@ use serde::{Serialize, Deserialize};
 
 use crate::{Alignment, Id, IdPath, IdPathBuf, Identified};
 
-use super::{ModifierNode, ShapeNode};
+use super::{GestureNode, ModifierNode, ShapeNode};
 
 /// A rendered UI component tree.
 #[derive(Debug, Clone, PartialEq, Diff, Serialize, Deserialize)]
@@ -30,6 +30,7 @@ pub enum Node {
 
     // Wrapper
     Shape { shape: ShapeNode },
+    Gesture { wrapped: Box<Identified<Node>>, gesture: GestureNode, },
     Modified { wrapped: Box<Identified<Node>>, modifier: ModifierNode, }
 }
 

--- a/nuit-core/src/state.rs
+++ b/nuit-core/src/state.rs
@@ -19,6 +19,10 @@ impl<T> State<T> where T: 'static + Clone {
         }
     }
 
+    pub fn is_linked(&self) -> bool {
+        self.storage.borrow().is_some() && self.key.borrow().is_some()
+    }
+
     pub fn link(&self, storage: Rc<Storage>, id_path: &IdPath, i: usize) {
         let key = (id_path.to_owned(), i);
 

--- a/nuit-core/src/utils/color.rs
+++ b/nuit-core/src/utils/color.rs
@@ -42,16 +42,19 @@ impl Color {
     }
 
     /// A random RGBA color.
+    #[cfg(feature = "rand")]
     pub fn random_rgba() -> Self {
         Self::new(rand::random(), rand::random(), rand::random(), rand::random())
     }
 
     /// A random RGB color with alpha 1.
+    #[cfg(feature = "rand")]
     pub fn random_rgb() -> Self {
         Self::with_rgb(rand::random(), rand::random(), rand::random())
     }
 
     /// A random grayscale color with alpha 1.
+    #[cfg(feature = "rand")]
     pub fn random_grayscale() -> Self {
         Self::with_grayscale(rand::random())
     }

--- a/nuit-core/src/utils/color.rs
+++ b/nuit-core/src/utils/color.rs
@@ -38,6 +38,16 @@ impl Color {
         Self::new(gray, gray, gray, 1.0)
     }
 
+    /// A random RGBA color.
+    pub fn random_rgba() -> Self {
+        Self::new(rand::random(), rand::random(), rand::random(), rand::random())
+    }
+
+    /// A random RGB color that is not transparent.
+    pub fn random_rgb() -> Self {
+        Self::new(rand::random(), rand::random(), rand::random(), 1.0)
+    }
+
     pub fn with_hsva(hue: Angle, saturation: f64, value: f64, alpha: f64) -> Self {
         let hue_degrees = hue.degrees().rem_euclid(360.0);
 

--- a/nuit-core/src/utils/color.rs
+++ b/nuit-core/src/utils/color.rs
@@ -48,7 +48,12 @@ impl Color {
 
     /// A random RGB color with alpha 1.
     pub fn random_rgb() -> Self {
-        Self::new(rand::random(), rand::random(), rand::random(), 1.0)
+        Self::with_rgb(rand::random(), rand::random(), rand::random())
+    }
+
+    /// A random grayscale color with alpha 1.
+    pub fn random_grayscale() -> Self {
+        Self::with_grayscale(rand::random())
     }
 
     /// Creates a new color with the given HSV value and alpha.

--- a/nuit-core/src/utils/color.rs
+++ b/nuit-core/src/utils/color.rs
@@ -26,14 +26,17 @@ impl Color {
     pub const MAGENTA: Self = Self::with_rgb(1.0, 0.0, 1.0);
     pub const YELLOW: Self = Self::with_rgb(1.0, 1.0, 0.0);
 
+    /// Creates a new color with the given RGBA components.
     pub const fn new(red: f64, green: f64, blue: f64, alpha: f64) -> Self {
         Self { red, green, blue, alpha }
     }
 
+    /// Creates a new color with the given RGB components and alpha 1.
     pub const fn with_rgb(red: f64, green: f64, blue: f64) -> Self {
         Self::new(red, green, blue, 1.0)
     }
 
+    /// Creates a new color with the given grayscale value and alpha 1.
     pub const fn with_grayscale(gray: f64) -> Self {
         Self::new(gray, gray, gray, 1.0)
     }
@@ -43,11 +46,12 @@ impl Color {
         Self::new(rand::random(), rand::random(), rand::random(), rand::random())
     }
 
-    /// A random RGB color that is not transparent.
+    /// A random RGB color with alpha 1.
     pub fn random_rgb() -> Self {
         Self::new(rand::random(), rand::random(), rand::random(), 1.0)
     }
 
+    /// Creates a new color with the given HSV value and alpha.
     pub fn with_hsva(hue: Angle, saturation: f64, value: f64, alpha: f64) -> Self {
         let hue_degrees = hue.degrees().rem_euclid(360.0);
 
@@ -77,6 +81,7 @@ impl Color {
         }
     }
 
+    /// Creates a new color with the given HSV value.
     pub fn with_hsv(hue: Angle, saturation: f64, value: f64) -> Self {
         Self::with_hsva(hue, saturation, value, 1.0)
     }


### PR DESCRIPTION
This adds a `Gesture` trait, along with common gestures (such as `TapGesture`) and corresponding view extensions.

The `Gesture` trait is similar to `View` in that it requires `Bind` and uses an id-path-based rendering and event dispatching model, thus user-defined gestures can contain state etc.