### PR TITLE
Add ScrollView support

### DIFF
--- a/examples/scroll_view.rs
+++ b/examples/scroll_view.rs
@@ -1,0 +1,97 @@
+#![feature(type_alias_impl_trait, impl_trait_in_assoc_type)]
+
+use nuit::{prelude::*, Axis, Color, Font, ForEach, HStack, Rectangle, ScrollView, Style, Text, VStack};
+
+#[derive(Bind)]
+struct ScrollViewExample;
+
+impl View for ScrollViewExample {
+    type Body = impl View;
+
+    fn body(&self) -> Self::Body {
+        VStack::from((
+            Text::new("ScrollView Example").font(Font::TITLE).padding(20.0),
+            
+            // Vertical ScrollView (default)
+            VStack::from((
+                Text::new("Vertical ScrollView:").font(Font::HEADLINE),
+                ScrollView::from(
+                    VStack::from(
+                        ForEach::new(0..50, |i| {
+                            Text::new(format!("Item {}", i))
+                                .frame((300, 40))
+                                .padding(5.0)
+                        })
+                    )
+                )
+                .frame((350, 300))
+                .border(Style::color(Color::GRAY), 1.0),
+            )).padding(10.0),
+            
+            // Horizontal ScrollView  
+            VStack::from((
+                Text::new("Horizontal ScrollView:").font(Font::HEADLINE),
+                ScrollView::horizontal(
+                    HStack::from(
+                        ForEach::new(0..20, |i| {
+                            VStack::from((
+                                Rectangle::new()
+                                    .frame((100, 100))
+                                    .foreground_style(Style::color(Color::new(
+                                        (i as f64 * 0.05).min(1.0),
+                                        0.5,
+                                        1.0 - (i as f64 * 0.05).min(1.0),
+                                        1.0
+                                    ))),
+                                Text::new(format!("Card {}", i)),
+                            ))
+                            .padding(10.0)
+                        })
+                    )
+                )
+                .frame((350, 150))
+                .border(Style::color(Color::GRAY), 1.0),
+            )).padding(10.0),
+            
+            // Both axes ScrollView
+            VStack::from((
+                Text::new("Both Axes ScrollView:").font(Font::HEADLINE),
+                ScrollView::new(Axis::Both,
+                    VStack::from(
+                        ForEach::new(0..30, |row| {
+                            HStack::from(
+                                ForEach::new(0..10, |col| {
+                                    Text::new(format!("{},{}", row, col))
+                                        .frame((60, 40))
+                                        .padding(2.0)
+                                })
+                            )
+                        })
+                    )
+                )
+                .frame((350, 200))
+                .border(Style::color(Color::GRAY), 1.0),
+            )).padding(10.0),
+            
+            // ScrollView without indicators
+            VStack::from((
+                Text::new("No Indicators:").font(Font::HEADLINE),
+                ScrollView::vertical(
+                    VStack::from(
+                        ForEach::new(0..20, |i| {
+                            Text::new(format!("Hidden scrollbar item {}", i))
+                                .padding(10.0)
+                        })
+                    )
+                )
+                .show_indicators(false)
+                .frame((350, 150))
+                .border(Style::color(Color::GRAY), 1.0),
+            )).padding(10.0),
+        ))
+    }
+}
+
+fn main() {
+    nuit::run_app(ScrollViewExample);
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
@@ -20,6 +20,7 @@ indirect enum Node: Codable, Hashable {
     case hStack(alignment: VerticalAlignment, spacing: Double, wrapped: Identified<Node>)
     case zStack(alignment: Alignment, spacing: Double, wrapped: Identified<Node>)
     case list(wrapped: Identified<Node>)
+    case scrollView(axes: Axis, showIndicators: Bool, wrapped: Identified<Node>)
     case overlay(wrapped: Identified<Node>, alignment: Alignment, overlayed: Identified<Node>)
 
     // MARK: Navigation

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
@@ -78,6 +78,10 @@ struct NodeView: View {
             List {
                 childView(for: wrapped)
             }
+        case let .scrollView(axes: axes, showIndicators: showIndicators, wrapped: wrapped):
+            ScrollView(axes.swiftUIAxes, showsIndicators: showIndicators) {
+                childView(for: wrapped)
+            }
         case let .overlay(wrapped: wrapped, alignment: alignment, overlayed: overlayed):
             childView(for: wrapped)
                 .overlay(alignment: .init(alignment)) {

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUICore/Utils/Axis+SwiftUI.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUICore/Utils/Axis+SwiftUI.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension Axis {
+    public var swiftUIAxes: SwiftUI.Axis.Set {
+        switch self {
+        case .horizontal:
+            return .horizontal
+        case .vertical:
+            return .vertical
+        case .both:
+            return [.horizontal, .vertical]
+        }
+    }
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUICore/Utils/Axis.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUICore/Utils/Axis.swift
@@ -1,0 +1,5 @@
+public enum Axis: String, Codable, Hashable {
+    case horizontal
+    case vertical
+    case both
+}

--- a/nuit-core/src/compose/view/layout/mod.rs
+++ b/nuit-core/src/compose/view/layout/mod.rs
@@ -1,9 +1,11 @@
 mod geometry_reader;
 mod list;
 mod overlay;
+mod scroll_view;
 mod stack;
 
 pub use geometry_reader::*;
 pub use list::*;
 pub use overlay::*;
+pub use scroll_view::*;
 pub use stack::*;

--- a/nuit-core/src/compose/view/layout/scroll_view.rs
+++ b/nuit-core/src/compose/view/layout/scroll_view.rs
@@ -1,0 +1,88 @@
+use nuit_derive::Bind;
+use serde::{Serialize, Deserialize};
+
+use crate::{Context, Event, EventResponse, Id, IdPath, IdentifyExt, Node, View};
+
+/// The axis along which a scroll view scrolls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Axis {
+    /// Horizontal scrolling only
+    Horizontal,
+    /// Vertical scrolling only  
+    Vertical,
+    /// Both horizontal and vertical scrolling
+    Both,
+}
+
+impl Default for Axis {
+    fn default() -> Self {
+        Self::Vertical
+    }
+}
+
+/// A scrollable view that can contain content larger than the visible area.
+#[derive(Debug, Clone, PartialEq, Bind)]
+pub struct ScrollView<T> {
+    axes: Axis,
+    show_indicators: bool,
+    wrapped: T,
+}
+
+impl<T> ScrollView<T> {
+    /// Creates a new ScrollView with the given axes and wrapped content.
+    #[must_use]
+    pub fn new(axes: Axis, wrapped: T) -> Self {
+        Self {
+            axes,
+            show_indicators: true,
+            wrapped,
+        }
+    }
+
+    /// Creates a new vertical ScrollView with the wrapped content.
+    #[must_use]
+    pub fn vertical(wrapped: T) -> Self {
+        Self::new(Axis::Vertical, wrapped)
+    }
+
+    /// Creates a new horizontal ScrollView with the wrapped content.
+    #[must_use]
+    pub fn horizontal(wrapped: T) -> Self {
+        Self::new(Axis::Horizontal, wrapped)
+    }
+
+    /// Sets whether to show scroll indicators.
+    #[must_use]
+    pub fn show_indicators(mut self, show: bool) -> Self {
+        self.show_indicators = show;
+        self
+    }
+}
+
+impl<T> From<T> for ScrollView<T> {
+    fn from(wrapped: T) -> Self {
+        Self::vertical(wrapped)
+    }
+}
+
+impl<T> View for ScrollView<T> where T: View {
+    fn fire(&self, event: &Event, event_path: &IdPath, context: &Context) -> EventResponse {
+        if let Some(head) = event_path.head() {
+            match head {
+                Id::Index(0) => self.wrapped.fire(event, event_path.tail(), &context.child(0)),
+                i => panic!("Cannot fire event for child id {i} on ScrollView which only has one child"),
+            }
+        } else {
+            EventResponse::default()
+        }
+    }
+
+    fn render(&self, context: &Context) -> Node {
+        Node::ScrollView { 
+            axes: self.axes, 
+            show_indicators: self.show_indicators,
+            wrapped: Box::new(self.wrapped.render(&context.child(0)).identify(0))
+        }
+    }
+}

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -2,7 +2,7 @@ use nuit_derive::Diff;
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
 
-use crate::{Alignment, HorizontalAlignment, Id, IdPath, IdPathBuf, Identified, VerticalAlignment};
+use crate::{Alignment, Axis, HorizontalAlignment, Id, IdPath, IdPathBuf, Identified, VerticalAlignment};
 
 use super::{GestureNode, ModifierNode, ShapeNode};
 
@@ -29,6 +29,7 @@ pub enum Node {
     HStack { alignment: VerticalAlignment, spacing: f64, wrapped: Box<Identified<Node>> },
     ZStack { alignment: Alignment, spacing: f64, wrapped: Box<Identified<Node>> },
     List { wrapped: Box<Identified<Node>> },
+    ScrollView { axes: Axis, show_indicators: bool, wrapped: Box<Identified<Node>> },
     Overlay { wrapped: Box<Identified<Node>>, alignment: Alignment, overlayed: Box<Identified<Node>> },
 
     // Navigation


### PR DESCRIPTION
## Summary
Adds ScrollView support to nuit, enabling scrollable content that exceeds the visible area - a critical component for building non-trivial UIs.

## Features
- **Configurable scroll axes**: horizontal, vertical, or both
- **Show/hide scroll indicators**: control scroll bar visibility
- **Convenient constructors**: `ScrollView::vertical()` and `ScrollView::horizontal()`
- **Default behavior**: vertical scrolling (most common use case)

## Implementation Details

### Core (Rust)
- Added `ScrollView<T>` struct following the same pattern as other layout containers
- Added `Axis` enum with three variants: `Horizontal`, `Vertical`, `Both`
- Implements the standard `View` trait with proper event forwarding
- Uses `#[serde(rename_all = "camelCase")]` for JSON compatibility

### SwiftUI Bridge
- Added `Axis` enum in Swift matching the Rust side
- Added extension to convert to SwiftUI's `Axis.Set`
- Integrated ScrollView case into `NodeView`
- Proper Codable implementation for JSON serialization

## Example
The PR includes a comprehensive example (`examples/scroll_view.rs`) demonstrating:
- Vertical scrolling with a list of items
- Horizontal scrolling with card-like views
- Both-axes scrolling with a grid layout
- Hiding scroll indicators

## Testing
- [x] Tested with SwiftUI backend on macOS
- [x] Example runs successfully
- [x] All scroll configurations work as expected
- [ ] TODO: Test with Adwaita backend when ScrollView is implemented there

## Notes
The example currently avoids using `.background()` modifier due to the EdgeSet serialization issue (being addressed separately). Once that's fixed, the example can be enhanced with background colors for better visual demonstration.