### PR TITLE
Add Toggle widget support

### DIFF
--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -1,0 +1,59 @@
+#![feature(type_alias_impl_trait, impl_trait_in_assoc_type)]
+
+use nuit::{prelude::*, Toggle, VStack, HStack, Text, Font, FontLevel, Insets};
+
+#[derive(Bind, Default)]
+struct ToggleExample {
+    is_on: State<bool>,
+    airplane_mode: State<bool>,
+    wifi_enabled: State<bool>,
+}
+
+impl ToggleExample {
+    fn new() -> Self {
+        Self {
+            is_on: State::new(false),
+            airplane_mode: State::new(false),
+            wifi_enabled: State::new(true),
+        }
+    }
+}
+
+impl View for ToggleExample {
+    type Body = impl View;
+
+    fn body(&self) -> Self::Body {
+        VStack::with_spacing(20.0, (
+            Text::new("Toggle Examples").font(Font::with_level(FontLevel::LargeTitle)),
+            
+            VStack::with_spacing(10.0, (
+                HStack::from((
+                    Text::new("Basic Toggle"),
+                    Toggle::new(self.is_on.binding()),
+                )),
+                
+                HStack::from((
+                    Text::new("Airplane Mode"),
+                    Toggle::new(self.airplane_mode.binding()),
+                )),
+                
+                HStack::from((
+                    Text::new("Wi-Fi"),
+                    Toggle::new(self.wifi_enabled.binding()),
+                )),
+            )),
+            
+            VStack::with_spacing(5.0, (
+                Text::new("Current States:").font(Font::with_level(FontLevel::Headline)),
+                Text::new(format!("Basic Toggle: {}", if self.is_on.get() { "ON" } else { "OFF" })),
+                Text::new(format!("Airplane Mode: {}", if self.airplane_mode.get() { "ON" } else { "OFF" })),
+                Text::new(format!("Wi-Fi: {}", if self.wifi_enabled.get() { "Enabled" } else { "Disabled" })),
+            )),
+        ))
+        .padding(Insets::default())
+    }
+}
+
+fn main() {
+    nuit::run_app(ToggleExample::new());
+}

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event/Event.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Event/Event.swift
@@ -6,6 +6,7 @@ enum Event: Codable, Hashable {
     case updateText(content: String)
     case updatePickerSelection(id: Id)
     case updateSliderValue(value: Double)
+    case toggleChange
     case updateNavigationPath(path: [Value])
     case getNavigationDestination(value: Value)
     case getGeometryReaderView(geometry: Geometry)

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/Node.swift
@@ -9,6 +9,7 @@ indirect enum Node: Codable, Hashable {
     case button(label: Identified<Node>)
     case picker(title: String, selection: Id, content: Identified<Node>)
     case slider(value: Double, lowerBound: Double, upperBound: Double, step: Double?)
+    case toggle(isOn: Bool)
 
     // MARK: Aggregation
     case child(wrapped: Identified<Node>)

--- a/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
+++ b/nuit-bridge-swiftui/Sources/NuitBridgeSwiftUI/NodeView.swift
@@ -45,6 +45,13 @@ struct NodeView: View {
             } else {
                 Slider(value: binding, in: lowerBound...upperBound)
             }
+        case let .toggle(isOn: isOn):
+            Toggle(isOn: Binding(
+                get: { isOn },
+                set: { _ in root.fire(event: .toggleChange, for: idPath) }
+            )) {
+                EmptyView()
+            }
 
         // MARK: Aggregation
         case let .child(wrapped: wrapped):

--- a/nuit-core/src/compose/view/widget/mod.rs
+++ b/nuit-core/src/compose/view/widget/mod.rs
@@ -3,9 +3,11 @@ mod picker;
 mod slider;
 mod text_field;
 mod text;
+mod toggle;
 
 pub use button::*;
 pub use picker::*;
 pub use slider::*;
 pub use text_field::*;
 pub use text::*;
+pub use toggle::*;

--- a/nuit-core/src/compose/view/widget/toggle.rs
+++ b/nuit-core/src/compose/view/widget/toggle.rs
@@ -1,0 +1,32 @@
+use nuit_derive::Bind;
+
+use crate::{Access, Binding, Context, Event, EventResponse, IdPath, Node, View};
+
+/// A control that toggles between on and off states.
+#[derive(Debug, Clone, Bind)]
+pub struct Toggle {
+    is_on: Binding<bool>,
+}
+
+impl Toggle {
+    /// Creates a new Toggle with the given binding.
+    #[must_use]
+    pub fn new(is_on: Binding<bool>) -> Self {
+        Self { is_on }
+    }
+}
+
+impl View for Toggle {
+    fn fire(&self, event: &Event, event_path: &IdPath, _context: &Context) -> EventResponse {
+        assert!(event_path.is_root());
+        if let Event::ToggleChange {} = event {
+            let current = self.is_on.get();
+            self.is_on.set(!current);
+        }
+        EventResponse::default()
+    }
+
+    fn render(&self, _context: &Context) -> Node {
+        Node::Toggle { is_on: self.is_on.get() }
+    }
+}

--- a/nuit-core/src/event/event.rs
+++ b/nuit-core/src/event/event.rs
@@ -15,6 +15,7 @@ pub enum Event {
     UpdateText { content: String },
     UpdatePickerSelection { id: Id },
     UpdateSliderValue { value: f64 },
+    ToggleChange {},
 
     // Navigation
     UpdateNavigationPath { path: Vec<Value> },

--- a/nuit-core/src/node/node.rs
+++ b/nuit-core/src/node/node.rs
@@ -18,6 +18,7 @@ pub enum Node {
     Button { label: Box<Identified<Node>> },
     Picker { title: String, selection: Id, content: Box<Identified<Node>> },
     Slider { value: f64, lower_bound: f64, upper_bound: f64, step: Option<f64> },
+    Toggle { is_on: bool },
 
     // Aggregation
     Child { wrapped: Box<Identified<Node>> },


### PR DESCRIPTION
## Summary
- Adds a new Toggle widget for boolean state controls
- Implements the widget in both Rust core and SwiftUI bridge
- Includes a comprehensive example demonstrating multiple toggle instances

## Implementation Details
The Toggle widget follows the existing patterns established by other widgets like Button and Slider:
- Uses `Binding<bool>` for state management
- Handles `ToggleChange` events to flip the boolean state
- Integrates seamlessly with the existing event system

## Example
The included example demonstrates:
- Basic toggle functionality
- Multiple toggles with independent state
- Real-time state display
- Proper use of the State and Binding APIs

## Testing
Tested with the SwiftUI backend on macOS. The toggle responds correctly to user interaction and updates the bound state as expected.